### PR TITLE
Update seed file to enforce id increments and allow updating rows

### DIFF
--- a/database/seeders/20200601074220-channels-hololive.js
+++ b/database/seeders/20200601074220-channels-hololive.js
@@ -2,11 +2,26 @@ const { TABLES } = require('../../consts');
 const hololive = require('./json/hololive.json');
 
 module.exports = {
-  up: (queryInterface) => queryInterface.bulkInsert(TABLES.CHANNEL, hololive.channels.map((item) => ({
-    yt_channel_id: item.youtube,
-    name: item.ytName,
-    twitter_link: item.twitter,
-  }))),
+  up: async (queryInterface, Sequelize) => {
+    // map json to index
+    const channels = hololive.channels.map((item, index) => ({
+      id: index + 1,
+      yt_channel_id: item.youtube,
+      name: item.ytName,
+      twitter_link: item.twitter,
+    }));
+
+    // bulk insert new channels
+    await queryInterface.bulkInsert(TABLES.CHANNEL, channels, { 
+      ignoreDuplicates: true,
+    });
+
+    // update channels
+    await Promise.all(channels.map((channel) => 
+      queryInterface.bulkUpdate(TABLES.CHANNEL, channel, {
+        id: channel.id
+    })));
+  },
 
   down: (queryInterface) => queryInterface.bulkDelete(TABLES.CHANNEL, {
     yt_channel_id: hololive.channels.map((item) => item.youtube),


### PR DESCRIPTION
The channel index increments based on the order of the channel in the hololive.json file, so any changes to the order in the file could be breaking. Might be worth hard coding the id in the json file.

Not sure what the current ids of the production database, since 5th gen might have been assigned a large id, which would mean manually going through and fixing the entries. A quick fix would be to hard code the id. 