### PR TITLE
Video count statuses

### DIFF
--- a/apps/client-api/routes/v1/channels.js
+++ b/apps/client-api/routes/v1/channels.js
@@ -29,7 +29,7 @@ router.get('/', limitChecker, asyncMiddleware(async (req, res) => {
   const { rows: videoRows } = await db.Video.findAndCountAll({
     attributes: ['channel_id', [db.client.fn('COUNT', 'channel_id'), 'video_count']],
     group: ['channel_id'],
-    where: { status: 'past' },
+    where: { status: ['past', 'live', 'upcoming'] },
   });
 
   // Distribute to respective channel objects


### PR DESCRIPTION
* client-api: include `live` and `upcoming` on video count
* try fix polka 101%

consideration:
* does youtube count upcoming towards video count? if not we can see more non-100% even if they dont have private videos