### PR TITLE
Change comments property to videos

### DIFF
--- a/api-doc/swagger_v1.yaml
+++ b/api-doc/swagger_v1.yaml
@@ -615,7 +615,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  data:
+                  videos:
                     type: array
                     description: >
                       List of videos, along with channel and matched comments.

--- a/apps/client-api/routes/v1/comments.js
+++ b/apps/client-api/routes/v1/comments.js
@@ -89,7 +89,7 @@ router.get('/search', limitChecker, asyncMiddleware(async (req, res) => {
     count: videos.length,
     total: await totalCount,
     query: sanitizedQuery,
-    comments: videos,
+    videos,
     cached: false,
   };
 


### PR DESCRIPTION
Since this endpoints returns videos with a comments property it would make much more sense to return a videos property.
Now you have `videos.comments` instead of `comments.comments` which doesn't make much sense.
Resolves #88 
Should be merged after #89 and a rebase has happened.